### PR TITLE
Independent draft number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@
 MD_FILE := draft-ietf-suit-mti.md
 DRAFT := $(shell grep 'docname: ' $(MD_FILE) | awk '{print $$2}')
 
+.PHONY: all
 all: $(DRAFT).xml $(DRAFT).txt $(DRAFT).html
 
 $(DRAFT).html: $(DRAFT).xml

--- a/README.md
+++ b/README.md
@@ -37,9 +37,42 @@ cd suit-mti
 make
 ```
 
-It will create `draft-ietf-suit-mti-latest.txt` and
-`draft-ietf-suit-mti-latest.xml`.
+It will create `draft-ietf-suit-mti.txt`, `draft-ietf-suit-mti.xml` and `draft-ietf-suit-mti.html`.
+
+## Updating repo on GitHub
+
+Make updates to the `draft-ietf-suit-mti.md` and/or `draft-ietf-suit-mti.cddl`.
+Regenerate xml, txt and html with `make` command.
+
+Commit and push to GitHub the changes on all files listed below.
+```
+draft-ietf-suit-mti.md
+draft-ietf-suit-mti.xml
+draft-ietf-suit-mti.txt
+draft-ietf-suit-mti.html
+```
+
+This way a person who would like to see the latest current draft will be able to see them in txt and html file format on GitHub.
 
 ## Submitting draft
 
-TBD
+Generate xml file containing version number only when submitting draft since the datatracker require the version number on both inside the xml and on the file name
+
+Instead of hard coding the version number in the md file, this way will make it easier to regularly update the md and cddl file in the repo on the github by keeping the file name consistent.
+Otherwise, it will require manually changing the file names back to the without version number every time when git commit and push.
+
+1)
+Revise the next line in the file ‘draft-ietf-suit-mti.md’
+```
+docname: draft-ietf-suit-mti
+```
+with adding the version number at the end for submitting the draft.
+For example, If the current draft version is ‘08’ then change it as the line below.
+```
+docname: draft-ietf-suit-mti-09
+```
+
+2)
+Generate the xml file with ‘make’ command.
+This will generate the ‘draft-ietf-suit-mti-09.xml’ for the example above.
+Upload the new xml file as the draft to the datatracker at ietf.

--- a/draft-ietf-suit-mti.html
+++ b/draft-ietf-suit-mti.html
@@ -13,7 +13,7 @@
     " name="description">
 <meta content="xml2rfc 3.16.0" name="generator">
 <meta content="Internet-Draft" name="keyword">
-<meta content="draft-ietf-suit-mti-08" name="ietf.draft">
+<meta content="draft-ietf-suit-mti" name="ietf.draft">
 <!-- Generator version information:
   xml2rfc 3.16.0
     Python 3.10.12
@@ -32,7 +32,7 @@
     six 1.16.0
     wcwidth 0.2.6
 -->
-<link href="draft-ietf-suit-mti-08.xml" rel="alternate" type="application/rfc+xml">
+<link href="draft-ietf-suit-mti.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1206,11 +1206,11 @@ li > p:last-of-type:only-child {
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">MTI SUIT Algorithms</td>
-<td class="right">November 2024</td>
+<td class="right">March 2025</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Moran, et al.</td>
-<td class="center">Expires 1 June 2025</td>
+<td class="center">Expires 3 September 2025</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1220,15 +1220,15 @@ li > p:last-of-type:only-child {
 <dt class="label-workgroup">Workgroup:</dt>
 <dd class="workgroup">SUIT</dd>
 <dt class="label-internet-draft">Internet-Draft:</dt>
-<dd class="internet-draft">draft-ietf-suit-mti-08</dd>
+<dd class="internet-draft">draft-ietf-suit-mti</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2024-11-28" class="published">28 November 2024</time>
+<time datetime="2025-03-02" class="published">2 March 2025</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2025-06-01">1 June 2025</time></dd>
+<dd class="expires"><time datetime="2025-09-03">3 September 2025</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1241,6 +1241,7 @@ li > p:last-of-type:only-child {
 </div>
 <div class="author">
       <div class="author-name">A. Tsukamoto</div>
+<div class="org">Openchip &amp; Software Technologies, S.L.</div>
 </div>
 </dd>
 </dl>
@@ -1269,7 +1270,7 @@ li > p:last-of-type:only-child {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 1 June 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 3 September 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1278,7 +1279,7 @@ li > p:last-of-type:only-child {
 <a href="#name-copyright-notice" class="section-name selfRef">Copyright Notice</a>
         </h2>
 <p id="section-boilerplate.2-1">
-            Copyright (c) 2024 IETF Trust and the persons identified as the
+            Copyright (c) 2025 IETF Trust and the persons identified as the
             document authors. All rights reserved.<a href="#section-boilerplate.2-1" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.2-2">
             This document is subject to BCP 78 and the IETF Trust's Legal
@@ -1782,7 +1783,7 @@ within this page. The initial content of the registry is:<a href="#section-6-2" 
 <dl class="references">
 <dt id="I-D.ietf-suit-manifest">[I-D.ietf-suit-manifest]</dt>
         <dd>
-<span class="refAuthor">Moran, B.</span>, <span class="refAuthor">Tschofenig, H.</span>, <span class="refAuthor">Birkholz, H.</span>, <span class="refAuthor">Zandberg, K.</span>, and <span class="refAuthor">O. Rønningstad</span>, <span class="refTitle">"A Concise Binary Object Representation (CBOR)-based Serialization Format for the Software Updates for Internet of Things (SUIT) Manifest"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-ietf-suit-manifest-29</span>, <time datetime="2024-11-07" class="refDate">7 November 2024</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-ietf-suit-manifest-29">https://datatracker.ietf.org/doc/html/draft-ietf-suit-manifest-29</a>&gt;</span>. </dd>
+<span class="refAuthor">Moran, B.</span>, <span class="refAuthor">Tschofenig, H.</span>, <span class="refAuthor">Birkholz, H.</span>, <span class="refAuthor">Zandberg, K.</span>, and <span class="refAuthor">O. Rønningstad</span>, <span class="refTitle">"A Concise Binary Object Representation (CBOR)-based Serialization Format for the Software Updates for Internet of Things (SUIT) Manifest"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-ietf-suit-manifest-33</span>, <time datetime="2025-02-24" class="refDate">24 February 2025</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-ietf-suit-manifest-33">https://datatracker.ietf.org/doc/html/draft-ietf-suit-manifest-33</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="RFC8152">[RFC8152]</dt>
         <dd>
@@ -1809,7 +1810,7 @@ within this page. The initial content of the registry is:<a href="#section-6-2" 
 <dl class="references">
 <dt id="I-D.ietf-suit-firmware-encryption">[I-D.ietf-suit-firmware-encryption]</dt>
         <dd>
-<span class="refAuthor">Tschofenig, H.</span>, <span class="refAuthor">Housley, R.</span>, <span class="refAuthor">Moran, B.</span>, <span class="refAuthor">Brown, D.</span>, and <span class="refAuthor">K. Takayama</span>, <span class="refTitle">"Encrypted Payloads in SUIT Manifests"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-ietf-suit-firmware-encryption-21</span>, <time datetime="2024-10-21" class="refDate">21 October 2024</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-ietf-suit-firmware-encryption-21">https://datatracker.ietf.org/doc/html/draft-ietf-suit-firmware-encryption-21</a>&gt;</span>. </dd>
+<span class="refAuthor">Tschofenig, H.</span>, <span class="refAuthor">Housley, R.</span>, <span class="refAuthor">Moran, B.</span>, <span class="refAuthor">Brown, D.</span>, and <span class="refAuthor">K. Takayama</span>, <span class="refTitle">"Encrypted Payloads in SUIT Manifests"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-ietf-suit-firmware-encryption-23</span>, <time datetime="2025-01-29" class="refDate">29 January 2025</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-ietf-suit-firmware-encryption-23">https://datatracker.ietf.org/doc/html/draft-ietf-suit-firmware-encryption-23</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="IANA-COSE">[IANA-COSE]</dt>
       <dd>
@@ -1986,9 +1987,10 @@ SUIT_COSE_Mac0&lt;authid&gt; = [
 </address>
 <address class="vcard">
         <div dir="auto" class="left"><span class="fn nameRole">Akira Tsukamoto</span></div>
+<div dir="auto" class="left"><span class="org">Openchip &amp; Software Technologies, S.L.</span></div>
 <div class="email">
 <span>Email:</span>
-<a href="mailto:akira.tsukamoto@alaxala.com" class="email">akira.tsukamoto@alaxala.com</a>
+<a href="mailto:akira.tsukamoto@gmail.com" class="email">akira.tsukamoto@gmail.com</a>
 </div>
 </address>
 </section>

--- a/draft-ietf-suit-mti.md
+++ b/draft-ietf-suit-mti.md
@@ -1,7 +1,7 @@
 ---
 title: Mandatory-to-Implement Algorithms for Authors and Recipients of Software Update for the Internet of Things manifests
 abbrev: MTI SUIT Algorithms
-docname: draft-ietf-suit-mti-08
+docname: draft-ietf-suit-mti
 category: std
 
 area: Security

--- a/draft-ietf-suit-mti.txt
+++ b/draft-ietf-suit-mti.txt
@@ -5,14 +5,15 @@
 SUIT                                                            B. Moran
 Internet-Draft                                               Arm Limited
 Intended status: Standards Track                          Ø. Rønningstad
-Expires: 1 June 2025                                Nordic Semiconductor
+Expires: 3 September 2025                           Nordic Semiconductor
                                                             A. Tsukamoto
-                                                        28 November 2024
+                                  Openchip & Software Technologies, S.L.
+                                                            2 March 2025
 
 
 Mandatory-to-Implement Algorithms for Authors and Recipients of Software
               Update for the Internet of Things manifests
-                         draft-ietf-suit-mti-08
+                          draft-ietf-suit-mti
 
 Abstract
 
@@ -35,12 +36,27 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 1 June 2025.
+   This Internet-Draft will expire on 3 September 2025.
 
 Copyright Notice
 
-   Copyright (c) 2024 IETF Trust and the persons identified as the
+   Copyright (c) 2025 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
+
+
+
+
+
+
+
+
+
+
+
+Moran, et al.           Expires 3 September 2025                [Page 1]
+
+Internet-Draft             MTI SUIT Algorithms                March 2025
+
 
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents (https://trustee.ietf.org/
@@ -51,26 +67,19 @@ Copyright Notice
    described in Section 4.e of the Trust Legal Provisions and are
    provided without warranty as described in the Revised BSD License.
 
-
-
-Moran, et al.              Expires 1 June 2025                  [Page 1]
-
-Internet-Draft             MTI SUIT Algorithms             November 2024
-
-
 Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
    2.  Algorithms  . . . . . . . . . . . . . . . . . . . . . . . . .   3
    3.  Profiles  . . . . . . . . . . . . . . . . . . . . . . . . . .   3
      3.1.   Symmetric MTI profile:
-           suit-sha256-hmac-a128kw-a128ctr . . . . . . . . . . . . .   3
+           suit-sha256-hmac-a128kw-a128ctr . . . . . . . . . . . . .   4
      3.2.  Current Constrained Asymmetric MTI Profile 1:
            suit-sha256-es256-ecdh-a128ctr  . . . . . . . . . . . . .   4
      3.3.  Current Constrained Asymmetric MTI Profile 2:
            suit-sha256-eddsa-ecdh-a128ctr  . . . . . . . . . . . . .   4
      3.4.  Current AEAD Asymmetric MTI Profile 1:
-           suit-sha256-es256-ecdh-a128gcm  . . . . . . . . . . . . .   4
+           suit-sha256-es256-ecdh-a128gcm  . . . . . . . . . . . . .   5
      3.5.  Current AEAD Asymmetric MTI Profile 2:
            suit-sha256-eddsa-ecdh-chacha-poly  . . . . . . . . . . .   5
      3.6.  Future Constrained Asymmetric MTI Profile 1:
@@ -98,6 +107,13 @@ Table of Contents
 
    *  Two "Current" AEAD Asymmetric MTI profiles
 
+
+
+Moran, et al.           Expires 3 September 2025                [Page 2]
+
+Internet-Draft             MTI SUIT Algorithms                March 2025
+
+
    *  One "Future" Constrained Asymmetric MTI profile
 
    At least one MTI algorithm in each category MUST be FIPS qualified.
@@ -106,13 +122,6 @@ Table of Contents
    powerful/complex manifest authors and constrained manifest
    recipients, the requirements for Recipients and Authors are
    different.
-
-
-
-Moran, et al.              Expires 1 June 2025                  [Page 2]
-
-Internet-Draft             MTI SUIT Algorithms             November 2024
-
 
    Recipients MAY choose which MTI profile they wish to implement.  It
    is RECOMMENDED that they implement the "Future" Asymmetric MTI
@@ -148,6 +157,19 @@ Internet-Draft             MTI SUIT Algorithms             November 2024
 
    Recognized profiles are defined below.
 
+
+
+
+
+
+
+
+
+Moran, et al.           Expires 3 September 2025                [Page 3]
+
+Internet-Draft             MTI SUIT Algorithms                March 2025
+
+
 3.1.   Symmetric MTI profile: suit-sha256-hmac-a128kw-a128ctr
 
               +================+=================+==========+
@@ -161,14 +183,6 @@ Internet-Draft             MTI SUIT Algorithms             November 2024
               +----------------+-----------------+----------+
               | Encryption     | A128CTR         | -65534   |
               +----------------+-----------------+----------+
-
-
-
-
-Moran, et al.              Expires 1 June 2025                  [Page 3]
-
-Internet-Draft             MTI SUIT Algorithms             November 2024
-
 
                                   Table 1
 
@@ -204,6 +218,14 @@ Internet-Draft             MTI SUIT Algorithms             November 2024
              | Encryption     | A128CTR          | -65534   |
              +----------------+------------------+----------+
 
+
+
+
+Moran, et al.           Expires 3 September 2025                [Page 4]
+
+Internet-Draft             MTI SUIT Algorithms                March 2025
+
+
                                  Table 3
 
 3.4.  Current AEAD Asymmetric MTI Profile 1: suit-sha256-es256-ecdh-
@@ -218,14 +240,6 @@ Internet-Draft             MTI SUIT Algorithms             November 2024
              +----------------+------------------+----------+
              | Key Exchange   | ECDH-ES + A128KW | -29      |
              +----------------+------------------+----------+
-
-
-
-Moran, et al.              Expires 1 June 2025                  [Page 4]
-
-Internet-Draft             MTI SUIT Algorithms             November 2024
-
-
              | Encryption     | A128GCM          | 1        |
              +----------------+------------------+----------+
 
@@ -260,6 +274,14 @@ Internet-Draft             MTI SUIT Algorithms             November 2024
                  +----------------+-----------+----------+
                  | Key Exchange   | A256KW    | -5       |
                  +----------------+-----------+----------+
+
+
+
+Moran, et al.           Expires 3 September 2025                [Page 5]
+
+Internet-Draft             MTI SUIT Algorithms                March 2025
+
+
                  | Encryption     | A256CTR   | -65532   |
                  +----------------+-----------+----------+
 
@@ -267,20 +289,6 @@ Internet-Draft             MTI SUIT Algorithms             November 2024
 
    This draft does not specify a particular set of HSS-LMS parameters.
    Deep trees are RECOMMENDED due to key lifetimes in IoT devices.
-
-
-
-
-
-
-
-
-
-
-Moran, et al.              Expires 1 June 2025                  [Page 5]
-
-Internet-Draft             MTI SUIT Algorithms             November 2024
-
 
 4.  Reporting Profiles
 
@@ -323,20 +331,15 @@ Internet-Draft             MTI SUIT Algorithms             November 2024
    IANA is requested to create a page for COSE Algorithm Profiles within
    the category for Software Update for the Internet of Things (SUIT)
 
+
+
+Moran, et al.           Expires 3 September 2025                [Page 6]
+
+Internet-Draft             MTI SUIT Algorithms                March 2025
+
+
    IANA is also requested to create a registry for COSE Alforithm
    Profiles within this page.  The initial content of the registry is:
-
-
-
-
-
-
-
-
-Moran, et al.              Expires 1 June 2025                  [Page 6]
-
-Internet-Draft             MTI SUIT Algorithms             November 2024
-
 
    +=============+=========+======+====+========+==========+==========+=========+
    |Profile      |Status   |Digest|Auth|Key     |Encryption|Descriptor|Reference|
@@ -376,23 +379,29 @@ Internet-Draft             MTI SUIT Algorithms             November 2024
 
 7.1.  Normative References
 
+
+
+
+
+
+
+
+
+
+
+Moran, et al.           Expires 3 September 2025                [Page 7]
+
+Internet-Draft             MTI SUIT Algorithms                March 2025
+
+
    [I-D.ietf-suit-manifest]
               Moran, B., Tschofenig, H., Birkholz, H., Zandberg, K., and
               O. Rønningstad, "A Concise Binary Object Representation
               (CBOR)-based Serialization Format for the Software Updates
               for Internet of Things (SUIT) Manifest", Work in Progress,
-              Internet-Draft, draft-ietf-suit-manifest-29, 7 November
-              2024, <https://datatracker.ietf.org/doc/html/draft-ietf-
-              suit-manifest-29>.
-
-
-
-
-
-Moran, et al.              Expires 1 June 2025                  [Page 7]
-
-Internet-Draft             MTI SUIT Algorithms             November 2024
-
+              Internet-Draft, draft-ietf-suit-manifest-33, 24 February
+              2025, <https://datatracker.ietf.org/doc/html/draft-ietf-
+              suit-manifest-33>.
 
    [RFC8152]  Schaad, J., "CBOR Object Signing and Encryption (COSE)",
               RFC 8152, DOI 10.17487/RFC8152, July 2017,
@@ -419,9 +428,9 @@ Internet-Draft             MTI SUIT Algorithms             November 2024
               Tschofenig, H., Housley, R., Moran, B., Brown, D., and K.
               Takayama, "Encrypted Payloads in SUIT Manifests", Work in
               Progress, Internet-Draft, draft-ietf-suit-firmware-
-              encryption-21, 21 October 2024,
+              encryption-23, 29 January 2025,
               <https://datatracker.ietf.org/doc/html/draft-ietf-suit-
-              firmware-encryption-21>.
+              firmware-encryption-23>.
 
    [IANA-COSE]
               "CBOR Object Signing and Encryption (COSE)", 2022,
@@ -434,21 +443,16 @@ Appendix A.  A.  Full CDDL
    messages, but untagged messages are also defined for use in protocols
    that share a ciphersuite with SUIT.
 
+
+
+Moran, et al.           Expires 3 September 2025                [Page 8]
+
+Internet-Draft             MTI SUIT Algorithms                March 2025
+
+
    To be valid, the following CDDL MUST have the COSE CDDL appended to
    it.  The COSE CDDL can be obtained by following the directions in
    [RFC9052], Section 1.4.
-
-
-
-
-
-
-
-
-Moran, et al.              Expires 1 June 2025                  [Page 8]
-
-Internet-Draft             MTI SUIT Algorithms             November 2024
-
 
    SUIT_COSE_tool_tweak /= suit-sha256-hmac-a128kw-a128ctr
    SUIT_COSE_tool_tweak /= suit-sha256-es256-ecdh-a128ctr
@@ -494,18 +498,18 @@ Internet-Draft             MTI SUIT Algorithms             November 2024
        SUIT_COSE_Encrypt0_Tagged<encid> / SUIT_COSE_Mac_Tagged<authid> /
        SUIT_COSE_Mac0_Tagged<authid>
 
+
+
+
+Moran, et al.           Expires 3 September 2025                [Page 9]
+
+Internet-Draft             MTI SUIT Algorithms                March 2025
+
+
    ; Note: This is not the same definition as is used in COSE.
    ; It restricts a COSE header definition further without
    ; repeating the COSE definition. It should be merged
    ; with COSE by using the CDDL .and operator.
-
-
-
-Moran, et al.              Expires 1 June 2025                  [Page 9]
-
-Internet-Draft             MTI SUIT Algorithms             November 2024
-
-
    SUIT_COSE_Profile_Headers<algid> = (
        protected : bstr .cbor SUIT_COSE_alg_map<algid>,
        unprotected : SUIT_COSE_header_map
@@ -550,16 +554,17 @@ Internet-Draft             MTI SUIT Algorithms             November 2024
 
    SUIT_COSE_Encrypt<encid> = [
        SUIT_COSE_Profile_Headers<encid>,
+
+
+
+Moran, et al.           Expires 3 September 2025               [Page 10]
+
+Internet-Draft             MTI SUIT Algorithms                March 2025
+
+
        ciphertext : bstr / nil,
        recipients : [+SUIT_COSE_recipient<encid>]
    ]
-
-
-
-
-Moran, et al.              Expires 1 June 2025                 [Page 10]
-
-Internet-Draft             MTI SUIT Algorithms             November 2024
 
 
    SUIT_COSE_recipient<encid> = [
@@ -605,21 +610,22 @@ Authors' Addresses
    Email: brendan.moran.ietf@gmail.com
 
 
+
+
+
+Moran, et al.           Expires 3 September 2025               [Page 11]
+
+Internet-Draft             MTI SUIT Algorithms                March 2025
+
+
    Øyvind Rønningstad
    Nordic Semiconductor
    Email: oyvind.ronningstad@gmail.com
 
 
-
-
-
-Moran, et al.              Expires 1 June 2025                 [Page 11]
-
-Internet-Draft             MTI SUIT Algorithms             November 2024
-
-
    Akira Tsukamoto
-   Email: akira.tsukamoto@alaxala.com
+   Openchip & Software Technologies, S.L.
+   Email: akira.tsukamoto@gmail.com
 
 
 
@@ -663,10 +669,4 @@ Internet-Draft             MTI SUIT Algorithms             November 2024
 
 
 
-
-
-
-
-
-
-Moran, et al.              Expires 1 June 2025                 [Page 12]
+Moran, et al.           Expires 3 September 2025               [Page 12]

--- a/draft-ietf-suit-mti.xml
+++ b/draft-ietf-suit-mti.xml
@@ -20,7 +20,7 @@
 <?rfc docmapping="yes"?>
 <?rfc toc_levels="4"?>
 
-<rfc ipr="trust200902" docName="draft-ietf-suit-mti-08" category="std" tocInclude="true" sortRefs="true" symRefs="true">
+<rfc ipr="trust200902" docName="draft-ietf-suit-mti" category="std" tocInclude="true" sortRefs="true" symRefs="true">
   <front>
     <title abbrev="MTI SUIT Algorithms">Mandatory-to-Implement Algorithms for Authors and Recipients of Software Update for the Internet of Things manifests</title>
 
@@ -37,13 +37,13 @@
       </address>
     </author>
     <author initials="A." surname="Tsukamoto" fullname="Akira Tsukamoto">
-      <organization></organization>
+      <organization>Openchip &amp; Software Technologies, S.L.</organization>
       <address>
-        <email>akira.tsukamoto@alaxala.com</email>
+        <email>akira.tsukamoto@gmail.com</email>
       </address>
     </author>
 
-    <date year="2024" month="November" day="28"/>
+    <date year="2025" month="March" day="02"/>
 
     <area>Security</area>
     <workgroup>SUIT</workgroup>
@@ -409,20 +409,21 @@ within this page. The initial content of the registry is:</t>
       <author fullname='Øyvind Rønningstad' initials='O.' surname='Rønningstad'>
          <organization>Nordic Semiconductor</organization>
       </author>
-      <date day='7' month='November' year='2024'/>
+      <date day='24' month='February' year='2025'/>
       <abstract>
 	 <t>   This specification describes the format of a manifest.  A manifest is
    a bundle of metadata about code/data obtained by a recipient (chiefly
-   the firmware for an IoT device), where to find the code/data, the
-   devices to which it applies, and cryptographic information protecting
-   the manifest.  Software updates and Trusted Invocation both tend to
-   use sequences of common operations, so the manifest encodes those
-   sequences of operations, rather than declaring the metadata.
+   the firmware for an Internet of Things (IoT) device), where to find
+   the code/data, the devices to which it applies, and cryptographic
+   information protecting the manifest.  Software updates and Trusted
+   Invocation both tend to use sequences of common operations, so the
+   manifest encodes those sequences of operations, rather than declaring
+   the metadata.
 
 	 </t>
       </abstract>
    </front>
-   <seriesInfo name='Internet-Draft' value='draft-ietf-suit-manifest-29'/>
+   <seriesInfo name='Internet-Draft' value='draft-ietf-suit-manifest-33'/>
    
 </reference>
 
@@ -454,7 +455,7 @@ within this page. The initial content of the registry is:</t>
       <author fullname='Ken Takayama' initials='K.' surname='Takayama'>
          <organization>SECOM CO., LTD.</organization>
       </author>
-      <date day='21' month='October' year='2024'/>
+      <date day='29' month='January' year='2025'/>
       <abstract>
 	 <t>   This document specifies techniques for encrypting software, firmware,
    machine learning models, and personalization data by utilizing the
@@ -467,7 +468,7 @@ within this page. The initial content of the registry is:</t>
 	 </t>
       </abstract>
    </front>
-   <seriesInfo name='Internet-Draft' value='draft-ietf-suit-firmware-encryption-21'/>
+   <seriesInfo name='Internet-Draft' value='draft-ietf-suit-firmware-encryption-23'/>
    
 </reference>
 
@@ -633,89 +634,89 @@ SUIT_COSE_Mac0<authid> = [
   </back>
 
 <!-- ##markdown-source:
-H4sIAAAAAAAAA9Va3XLbNha+51NgkpskNWVJsRNH23Sr2E7jaRxnLGc6nTbj
-gUhIQk0RLAlaUeP0OXq5j7HX2xfb7wDgj0TKP5mmM/UktkScc3Dw4fxLvu97
-WupIDNgxj0OuVbr0tfKP5kkk5iLWbBhNVSr1bJ6xiUrZMNczlWYMxOxUBDKR
-IMqYmrCRmugFTwV7l0COMNR6JthRrEUaC000ZzMZTzM257GciExnHh+PU3GJ
-zc+O2Ojd0VltOy9UQczn0CxM+UT7UuiJn+VS+3Mt/e6eF2AXEC8HLNOh52Fr
-PmAjEeTgX3oLlV5MU5UnAyPYuxBLPAoHpT7+AYn1PJmkA6bTPNP9bvdZt+95
-gYozEWd5NmCx8rxM47DnPFIxdFmKzEvkwGMsnQQizPQyck8Z0yqovZRxCGiK
-B5lKdSomWfl+OV95q1MZlMSBmhP25aqMIxlX24gP2o9kpn0IGasIZL569BVW
-gNicJwkwrulxHolLQUQ7wMjcHrT3sUY/MsbCiw47VimP3TML+otUwB7ilRWV
-TnFzv3EtVTxgw3TOXsu51CJ062LOZTRgY8vamRNrh+7t2ymtdHCuta3//KPD
-Tv/8bxyTXWgerqjw5x/LS0l21iRY1eQNLlYGuPu5xN2FeQAzXlVJGUmdVJWC
-Nqo07LCzLL/gc6XVijrDC5nyxtqKJqubcmLo6ILhWx7xD/hv9vRilc7BdCmI
-6fTl/l5vt1+8fPp0z7181sVT2EMm3Pud3Wd4r9NgHODJkX/QqfmFc6sBjDqe
-1OWv0k1kOidP9UUcpMuk0Pxo+Gbo75+MDu0xXFi4t//i5JSdjH8RgWYjOSX8
-jPcflszsAXE9vGfYShPDD8WBAet3+30rkadTASOfaZ1kg+3txWLRkTzmHWC4
-zbMMwo3Zb9N5za/Oh5meR57n+z7jYzgJD+CxiCIZ2XpuAlSWIAxNpEBMKmIH
-S1I1kZGwIcvElQIblvA0Ey6AcRfMtGLk74hdY6ERHWAI+K0SkfKxjBBNYBIz
-kYlKLrwsWhZbBzzCGwjhjEIHtIS3hogdoYDfu6iY26iYQ0rAcTJ7qLkMw0h4
-3n1GcSlVZLtA1PPKaFydiuLmkgUzHk8FU5dQU8u5YGEuzN4xE5cquqTr0TPE
-Qs0iyMgCnohOPYqTMiYwQkWcU7XBRk+DQOWA14ZxmXXY22KV1BhjY5GkgoJw
-WGnTsWgvZBRhfQIc2AQ2CK2VDITJExTq3UarANJON+HXvIgUBu49YifYabRE
-2KRAWt8Da2cLBTPOU4QlfY/t17YYZm0sWYNneDg8uIaYNr/3MtewoNvI97wh
-LkdwWCNyilmp7kDiHnkwY0V2Y8fvRmcE98ujtyP2a84jMvYQ9vMC4JM5GcRx
-FZnJxLADXu1KmSSPAbDxU7f/Fu5Hz1iiFiKd5BE8jbL9h8pHeC3J12+kJEjL
-zL9lcnwqfs1lagoG63O10oCElFUDLjKUk4kgWHGEGtnx8EeyEjg9W8wkAKjb
-CfZYQulsRpYpi9qkw440Qyg4Pdw/OT4+fHNweABKGL4hL8mMhuX1tF9Jh62p
-UnHzeMnifD6GhcN6FYSl5d032NwJYqVXNDXeWcXL2m1PiueAN+HLSPEws+4T
-C3KqsQkZdN0FhsYeapJBWjfHTgn2HY4B6WThwBJ2hNtJC5/OY5+MAQKk9fTq
-FB32A2TAFRUi9xiXhDMaKcWljV6dvHt9QCfIRITsgVOwfZFq2NKKVR2pMxNP
-nZVmhTVRUST4nAJaKIpdt5x1xALhJJMaSsGsAHjsm81FE2SYycTYQG0TOipd
-0mrEDsUlopQ1aY0AUD+ONd6aqQG0E4Mi7senkG6rYHJGQt5FP1BIIL6IV92c
-IL9fL3aR1EQ91Bs7phwOFZGyTPVMapXaWPkUwk14rvLhenw34fFATslvaxs+
-MnbiLpYQWVn7Hg50+MHlmlryeHDy9uzo5M3w9UMQ1SqAdhIcsUgaxtcVqoff
-yNDrkBYHGYtILQiW+//7T2skR51P1Us24/3dJ/5szgOf9/p7FwvzBzUR+3j/
-BopPnndV6crOlolg9QdXjCoZc/or7+p57QdvCxCvYNlDHzvgld97QpTrWF6x
-V8fDfUezayhWEAUDFPr+B/P0h5QnJOqxoauBaqn2z05p9cnu7uMdUAAf5vLS
-danG4c56q6iJzPwOwtkG0JoEfx9mhyNH8LQNscP9g1f+4Yh9VWAHwv6zL4FZ
-fw2zMMz4tZg1CP5GzA4ORkMi2PuCmLWVP7czsGkwv97AQPBPNLDv9o/xqncH
-nDYbFRTAPz9RqIE3GlaN6J9mXPszjn/97vZbKN973EU8ZH1jYoSdrcs+I5TN
-siyaZz69pgCPPy0poI3mb0wCo5H/+nhEJDtPWrMABFjgdlvsDIs1p+wTYrb1
-pcEVEr6wNYxtopauUJBBHvEUJZcpGQoNsMIBKRrfDjsQImEorZolTdFLXkBL
-tBmCOrqMKgwq0WxxZAuXU5EobIXKrMrvqAZj1EL0MKXSFVVRiCrO9LOrfchW
-TVHYPPo6TrUeWl9Ygit9bGVAIwEYBHUUabkljuWaafS2tkFH978FEVzn+Ity
-YQo5eAW2LA8C85qKpwwYlOUpz8wz4EkFNjox83Z1WFCVsKYIp+YTepFutuBb
-mPem/nIFZVENb9HOM9rkRntEfepqOBJqNQ0itBFQgCrhSx5RcGmW1aTTlgFH
-fOBU6N+Q6s3VFQNS43EyFKktuj3vpZvX8kslQx4HgoAOVT7WRiV37iwQMU+l
-Ks7uehaCukSt3umkthlyJX3ozkotfCnJnrjGJFzL4kreonsoEQBSGTU2SyO6
-aI8ORz55y5ymBkThxkJAKBOCffzo26nZp080DYkK4QVbVsASrMBCxl9jtXMf
-CKg1HJXeja2r4tx6rPUu2naiIlS7ZM1zWO+UG8MOZIoansbNMFlTto9aOiA2
-z4ExdVV5Qi5R2iUMQRRXZayxbLUDM9haCOE6NGrJk4jTlOuDZjOOvhoOawYx
-prOjkUaufTXxVQoobr/5QlgCGktw17/hWAm1ScatHRt6POig5jRlgnfShpVr
-QXG00RmUrXTkWvPgIhvYHqh8jGOutqcJDCq187yyT4Vw2Lomi6rFV0TirDyN
-iQAVF4IBjEsBtw78hYznxgEqzAo2SK0oQk8eFcYLHDZd8FZpe9JGormi0UsC
-K8cpTHizwJkJ3DKhKVk5DtsuVMDdRBKXt6z8ybg5DXMbLm4eSttgw1HtmQOa
-FQqTPab2UxuT/qp8WM79aGokY8/Ep2I6ZQast//k5wHF14esUoVHmdqgTyqm
-Eia0rOs0WdPJszpZL6MDGHOE3wF0wBW4e3fOXkqU5F5XZWWBZG5yB6uld0rm
-rFnz1BP0gciCVCaaPhZLU45yAYnROZwtHCin39S04ueKHQ/fHAzPTk5/LMoJ
-dI3MNoW1opz9/BMWt7Cyi1/+4y238vN7rH38eFPz+2lNm5ZmcJM2qJiL8q6p
-jf90i5au0aalq2wo0+yyNiqzd50yezcq02zXbkCGupjbINNjjqyBjPnp3YwM
-tUPXIFNvFW5CBiX2mjJ7NWX6NyBT7zfWFWqvvNsV2nliq9taFVsohDXSatdd
-Vb/NilvrdxTwb8QCwRotgv2wwrh/6d3V/JA+RElDRJnAZgLzmcsYmcRM3zpo
-PlAJ7B8cvEbfMMFrPwjD6JMdxlUp2hDYsEQBPsvHrro2QYmiE+U7M1On8NZh
-LxReaj6dIqJRrs1j9wbldIYgtTL4ch+ZmJSTU1HpaI3wgmGLjXO9QY4JocUU
-rdBGmmm/VoGKXEUNSInYZRVCua4zzqwoE6LYlOHWWo1iADBz5xm/NDNNq515
-jowl4tDGbqlt/K1WAx6TWDXWtrcbL2tySVDZI5S1lqIieOQah15nx6TW33//
-3Qj0SNtzkn+ulYrOUdXwC7b9/KYweyu+Zpi6HVsjoHzObnD9u+5Wc9Lb4dLm
-Ths5q+dVk9d81kp5TuPPczsWOHfDpVvzminNOU0X7s5KA4vPZF3d9bv948/Z
-df/VEP/63fO3J69/7D3u7twesdEIjfq5nQicu97f825RPTxnNp5SIC1Lgvfe
-LTJ9wbmWwNd42xNzybt3HW97Hm3s29u4ZT3jNbbsr223ITGVfJRwqnzzvsWc
-2wyXtVzX14WUnW9Yh0K8WTx2YblFbtOoW8UCkbuJbRh8u9i9O4ptOMMmbXt3
-V7ThI5tU7t9W3VbfaZcKE7C33yq6Kftr6i8pI6Kol+E3K0ILtoLGktSFrFO0
-SXnnknpBvE67bb47U9GfXUvtvoHk3V5+XRf6fo9bb25Mi71qtbbiuqKvC43Z
-Gqdb71YENYh4sHFHrHXLxTqu12OwfiJHfv3BGkRN/QuSDRdTnHKdbPVANylD
-Z16j8bx/sTeKvkp1Vps0lgNNU/pJO27LynkmiimS1wHvEc3f7DcMqX41xdlM
-cDvZKXkneWo+zqaaUOUafKlIhB1clBVfRW++fJGBMqKPblGRptAYTKakNLTj
-pRsHG24qBo3Hma9VoWfutDmy0QruEk3tRT4w6FAla0eAA0bfAmOdYOy+2GX5
-QX8+54nj2zJMeVxnq2jtyYnce+htEoGtPxopPfb8G2aeWamP6DN18yxeep/q
-NlnJLZk3E7eZ5XN2/0nn2d6Ddnd86K3z1xh/WjOiBp6W0h6hGNk6LLdZLCO7
-QuN2bofwA/bTV2suYlYKUe+99w2FVgig1a3VcjFrRQWnXss2DVc1wPXWgett
-Rq73BaFr17s9gtgbf/JgUyR92CajYr5JdUto9bNdnxmaNpWvvs5l7r2SWC44
-Weu3vr5OSpVX+Rco9u/PV21DNLa20gJ59zrMu38x6KuqtmQFaxlPH6wQtRt0
-PYE69e7icRtNGlWDe2je1i+i/R42RIaWhOZuYe143Y3n637xA76nAYP3f8eD
-ap8OMQAA
+H4sIAAAAAAAAA9Va3W7bRha+51MMGmCRpKZsKXbiaJvuKrbTGI3jwHJQFG1g
+jMiRNGuSw5JDK2qcPkcv9zH2evti+52Z4Y9EynaCpsAahi1xzpw5853/I/m+
+72mpIzFkJzwJuVbZ0tfKP47TSMQi0WwUzVQm9TzO2VRlbFToucpyBmJ2JgKZ
+ShDlTE3ZWE31gmeCvU3BRxhqPRfsONEiS4QmmvO5TGY5i3kipyLXuccnk0xc
+4fDzYzZ+e3zeOM4LVZDwGJKFGZ9qXwo99fNCaj/W0gtwBCiXQ5br0PNwLh+y
+sQgKbF56C5VdzjJVpEPD1bsUSzwKh5Uw/iHx9DyZZkOmsyLXg52dpzsDzwtU
+koskL/IhS5Tn5Ro3veCRSiDIUuReKoceY9k0EGGul5F7yphWQeOlTELgUj7I
+VaYzMc2r98t45a3OZFARByom4KtVmUQyqY8R77UfyVz7YDJREch89fBrrACu
+mKcpAG7IcRGJK0FEu8DIqA7S+1ijH5lg4XmPnaiMJ+6ZRfx5JmAMycqKymZQ
+269cS5UM2SiL2SsZSy1Cty5iLqMhm9itvZi29khp/5zRSg/3Wjv6j9977OyP
+/yQJGYXm4YoIf/y+vJJkZG2CVUleQ7EygO5jCd2FRQAbXhVJGU69TFWMNoo0
+6rHzvLjksdJqRZzRpcx4a21VktNUJMFcpuxvtTOci2CeqEjNpMi32Lj3qrcq
+Gye+PV3ybQjmJSqLwflKkMGdvTjY7+8NypdPnuy7l0938BRGkwv3fnfvKd7r
+LJgEeHLsH/YanuMcbwjLT6ZN/qt0U5nFJL6PC2XL1FyPiEavR/7B6fhoaC7h
+AsdXB89Pz9jp5F8i0GwsZwSyiQ9H1WZ2n3Y9+Mpsq+wQPxQphmywMxhYjjyb
+CXjCXOs0H25vLxaLnuQJ7wHobZ7nYG58Y5vua/703s91HHme7/uMT+BJPIBb
+I87k5BCFCWF5ikA1hQIYL6MLSzM1lZGwQc1EnhIblvIsFy7EcRfutGIUFKDQ
+idAIIbAW/FWpyPhERgg5sJu5yEXNF64YLcujAx7hDZhwRvEFUsKlQwSYUCA4
+OFMpbNwswCXguJm9VCzDMBKed49R8MoUGTgQ9bwqXte3osi6ZMGcJzPB1BXE
+1DIWLCyEOTth4kpFV6QePUfA1CwCjzzgqeg14zwJY6InRMQ9VRds9DQIVAF4
+baCXeY+9KVdJjAkOFmkmKFKHtTQ9i/ZCRhHWp8CBTWGDkFrJQJhMQsnAHbQK
+IJ10G35tRWQwcO8hO8VJ4yViK0Xb5hlYO18omHGRIXbpr9hB44hR3rUlb+0Z
+HY0ObyCmw796UWhY0F34e94IyhEc1ojEY1ZqHUjokQdzVqZAdvJ2fE5wvzh+
+M2a/FDwiYw9hP88BPpmTQRyqyE2uhh3w+lRKN0UCgI2fuvO3oB89Z6laiGxa
+RPA0qgfe1z7CG2VAUyMVQVbVBlumCsjEL4XMTElhfa5RPBCTqq6AIkM5nQqC
+FVdokJ2MfiQrgdOzxVwCgKad4IwlhM7nZJmyrF567FgzhIKzo4PTk5Oj14dH
+h6CE4RvyisxIWKmnWyU9tiZKvZsnS5YU8QQWDutVYJZVum9tczdIlF6R1Hhn
+HS8b2p6WzwFvypeR4mFu3ScR5FQTEzJI3SWGxh4anEHaNMdeBfYnXAPcycKB
+JewI2slKny4Sn4wBDKT19PoWPfYDeMAVFSL3BErCHQ2XUmnjl6dvXx3SDXIR
+IXvgFuxAZBq2tGJVx+rcxFNnpXlpTVQ5CR5TQAtFeeqWs45EIJzkUkMomBUA
+T3xzuGiDDDOZGhtoHEJXJSWtRuxQXCFKWZPWCADN61jjbZgaQDs1KEI/PoV0
+WyeTMxLyLvqBQgLxRbLq5gT5vWY5jKQmmqHe2DHlcIiIlGXqaxKrksbypxBu
+wnOdD9fjuwmPh3JGfts48KGxE6dYQmRl7Xs40NF7l2sayeP+6Zvz49PXo1cP
+QNSoALpJcMUyaRhfV6gefiVDb0JaXmQiIrUgWO7999+dkRzNAFUv+ZwP9h77
+85gHPu8P9i8X5h9qIvbh3i0UHz3vupaVnS9TwZoPrhlVMub21971s8YP3pYg
+XsOyRz5OwCu//5go17G8Zi9PRgeOZs9QrCCKDRDo+x/M0x8ynhKrR4auAaql
+Ojg/o9XHe3uPdkEBfJjLSzelGoc766+iJnLzNwjnG0BrE/x1mB2NHcGTLsSO
+Dg5f+kdj9nWJHQgHT78EZoM1zMIw5zdi1iL4CzE7PByPiGD/C2LWVf7czcBm
+QXyzgYHg/9HAvjs4wav+J+C02aggAH79VKEG3mhYDaL/N+M6mHP8Dna230D4
+/qMdxEM2MCZG2Nm67DNC2TzPozj36TUFePzrSAFdNH9hEhiP/VcnYyLZfdyZ
+BcDAArfXYWdYbDjlgBCzrS9Nt5Dwha1hbBO1dIWCDIqIZyi5TMlQSoAVDkjR
++PbYoRApQ2nVLmnKXvISUqLNENTR5VRhUIlmiyNbuJyJVOEoVGZ1fkc1mKAW
+oocZla6oikJUcaafXe1DthqCwubR13Gq9dD6whJc6WMrAxoJwCCoo8iqI3Et
+10yjt7UNuhm/5CgGC/xHuTADH7zCtrwIAvOaiqccGFTlKc/NM+BJBTY6MfN2
+dVhQl7CmCKfmE3KRbLbgW5j3pv5yBWVZDW/RyXM65FZ7RH3qajhiaiUNIrQR
+EIAq4SseUXBpl9Uk05YBR7znVOjfkuqN6sopqvE4GYrMFt2e98JNdPmVkiFP
+AkFAh6qYaCOSu3ceiIRnUpV3dz0LQV2h1ux0MtsMuZI+dHelFr7iZG/c2CRc
+y+JK3rJ7qBAAUjk1NkvDumyPjsY+eUtMUwOicGMhIJQLwT588O3U7ONHmoZE
+JfNyW17CEqzAQsbf2GrnPmDQaDhquVtH18W59VjrXXTsVEWodsmaY1jvjBvD
+DmSGGp5m0jBZU7aPOzogFhfAmLqqIiWXqOwShiBKVRlrrFrtwAy2FkK4Do1a
+8jTiNOV6r9mco6+Gw5pBjOnsaKRRaF9NfZUBirsfvhCWgMYS3PVvuFZKbZJx
+a7cNPR5kUDFNmeCddGDtWhAcbXQOYWsZudY8uMyHtgeqHuOaq+1pCoPK7Dyv
+6lPBHLauyaIa8RWROK9uYyJAvQvBAMalgFsP/kLGc+sAFWYFG6RWFKGniErj
+BQ6bFLxV2Z60kShWNHpJYeW4hQlvFjgzgVumNCWrxmHbpQjQTSShvGXtT8bN
+aZjbcnHzUNoGG45q7xzQrFCY7DGzn+uY9Ffnw2ruR1MjmXgmPpXTKTNgvftn
+Q/cpvj5gtSg8ytUGeTIxkzChZVOm6ZpMnpXJehldwJgj/A6gA67A6d05e8VR
+kntdV5UFkrnJHayR3imZs3bN00zQhyIPMplq+uAsyzjKBSRG53C2cKCcflvT
+ip9rdjJ6fTg6Pz37sSwn0DUy2xQ2inL2809Y3MLKHv74j7bcys/vsPbhw23N
+78c1aTqawU3SoGIuy7u2NP6TLVq6QZqOrrIlTLvL2ijM/k3C7N8qTLtduwUZ
+6mLugkyfObIWMuanfzsy1A7dgEyzVbgNGZTYa8LsN4QZ3IJMs99YF6i78u4W
+aPexrW4bVWwpENZIqj2nqkGXFXfW7yjgX4sFgjVaBPthhXH/yrvr+SF9iJKF
+iDKBzQTmM5cJMomZvvXQfKASODg8fIW+YYrXfhCG0Uc7jKtTtCGwYYkCfF5M
+XHVtghJFJ8p3ZqZO4a3Hniu81Hw2Q0SjXFsk7g3K6RxBamXw5T4yMSmnoKLS
+0Rrm5YYtNin0Bj4mhJZTtFIaaab9WgUqchU1ICVil1UI5abMuLOiTIhiU4Zb
+azWKAcDMnef8ysw0rXTmOTKWSEIbu6W28bdeDXhCbNVE295usmzwJUZVj1DV
+WoqK4LFrHPq9XZNaf/vtN8PQI2kviP+FViq6QFXDL9n2s9vC7J32tcPU3ba1
+AsrnnAbX/9TTGk56N1y63Gnjzvp53eS1n3VSXtD488KOBS7ccOnOe82U5oKm
+C5++lQYWn7l19dTvDk4+59SDlyP8DnYu3py++rH/aGf37oiNx2jUL+xE4ML1
+/p53h+rhGbPxlAJpVRK88+6Q6cudawl8bW93Yq727t+0tzuPts7tbzyymfFa
+Rw7WjtuQmKp9lHDqfPOuw5y7DJd1qOubksvut6xHId4snriw3MG3bdSdbIHI
+p7FtGXw32/1PZNtyhk3S9j9d0JaPbBJ5cFdxO32nmytMwGq/k3Wb9zfUX1JG
+RFEvw29XmJbbShpL0mSyTtHF5a1L6iXxOu22+e5MTX9+I7X7/pF3d/5NWej7
+PW69fTAt9uvVxorrir4pJWZrO936Tk3QgIgHG0/E2k612MT1ZgzWb+TIb75Y
+i6gtf0myQTHlLdfJVi90mzB05zUaz/s7e63oq1TnjUljNdA0pZ+047a8mmei
+mCJ+Pew9pvmb/Roi1a+mOJsLbic71d5pkZmPs6kmVIXGvkykwg4uqoqvpjdf
+vshBGdFHt6hIM0iMTaakNLSTpRsHm91UDBqPM1+rQs/c63JkIxXcJZpZRd43
+6FAla0eAQ0bfAmO9YOK+2GX3g/4i5qnbt2U2FUlzW01rb07k3gNvEwsc/cFw
+6bNn3zLzzHJ9SJ+pm2fJ0vvYtMmab7V5M3GXWT5j9x73nu7f73bHB976/sbG
+n9aMqIWnpbRXKEe2DsttlsjIrtC4ndsh/JD99PWai5iVktU7711LoBUCSHVn
+sVzMWhHBiddxTMtVDXD9deD6m5Hrf0HouuXujiBW44/vb4qkD7p41JtvE90S
+Wvls12eGpm3h669zGb3XHKsFx2td6+vrJFSlyj9BsH98vmgborG1lQ7Id27C
+fOdPBn1V1I6sYC3jyf0Vom6DbiZQJ96neNxGk0bV4B6at01FdOthQ2ToSGhO
+C2vX29l4v50vfsF3NGDw/gcsVFWKMDEAAA==
 
 -->
 


### PR DESCRIPTION
Generate xml file containing version number only when submitting draft.
The datatracker require the version number on both inside the xml and on the file name

Instead of hard coding the version number in the md file, removing the version number inside md fille will make it easier to regularly update the md and cddl file in the repo on the GitHub by keeping the file name consistent.

Otherwise, it will require manually changing the file names back to ones without version number every time when git commit and push.

Also enables a person who would like to see the latest current draft will be able to see them in txt and html file format on GitHub.